### PR TITLE
Disable MD013 & MD040

### DIFF
--- a/acend.json
+++ b/acend.json
@@ -1,5 +1,6 @@
 {
   "default": true,
+  "MD013": false,
   "MD003": {
     "style": "atx"
   },
@@ -12,6 +13,7 @@
   "MD035": {
     "style": "---"
   },
+  "MD040": false,
   "MD048": {
     "style": "backtick"
   }


### PR DESCRIPTION
I suggest to disable:
- [MD013](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013) Line Lenght, is set to 80, which is quite short and accually I don't want to create manual linebreaks only to keep the linter happy. Let the browser deal with linebreak.
- [MD040](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040), because the Copy-Code functionality in our labs uses the highlight div generated by the language specification in the fenced-code. With this, we can disable a copy-button for a codeblock